### PR TITLE
Update prepare-release.yml to use `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -36,4 +36,4 @@ jobs:
           draft: false
           body: An automated PR for next release.
           commit-message: Prepare for ${{ steps.update-changelog.outputs.new-version }}
-          token: ${{ secrets.REALM_CI_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `REALM_CI_PAT` is broken due to SSO.